### PR TITLE
[WIP] Configuration file manipulations

### DIFF
--- a/src/utils-conf.c
+++ b/src/utils-conf.c
@@ -1,0 +1,49 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+/**
+ * Replaces the default module with moduleName in the Gpredict conf
+ **/
+int setDefaultModule(char *moduleName) {
+    char buffer[1001];
+    char *file = "../../.config/Gpredict/gpredict.cfg"; // Contingent on setup
+    char newLine[1001];
+    char *token;
+    FILE *fp = fopen(file, "r");
+
+    if (fp == NULL) {
+        perror("Error while opening the file\n");
+        exit(1); // arbitrary status code
+    }
+
+    fread(buffer, 1, 1000, fp);
+
+    // Close file then reopen for writing
+    fclose(fp);
+    fp = fopen(file, "w");
+
+    token = strtok(buffer, "\n");
+
+    // Write contents of buffer into file
+    while (token != NULL) {
+        if (strstr(token, "OPEN_MODULES")) {
+            sprintf(newLine, "%s%s\n", "OPEN_MODULES=", moduleName);
+            fwrite(newLine, strlen(newLine), 1, fp);
+        } else {
+            sprintf(newLine, "%s\n", token);
+            fwrite(newLine, strlen(newLine), 1, fp);
+        }
+
+        token = strtok(NULL, "\n"); // move pointer to next string
+    }
+
+    fclose(fp);
+    return 0;
+}
+
+// For debugging purposes
+// int main() {
+//     setDefaultModule("Test");
+//     return 0;
+// }

--- a/src/utils-conf.c
+++ b/src/utils-conf.c
@@ -41,9 +41,3 @@ int setDefaultModule(char *moduleName) {
     fclose(fp);
     return 0;
 }
-
-// For debugging purposes
-// int main() {
-//     setDefaultModule("Test");
-//     return 0;
-// }

--- a/src/utils-conf.h
+++ b/src/utils-conf.h
@@ -1,0 +1,6 @@
+#ifndef UTILS_CONF_H
+#define UTILS_CONF_H
+
+void setDefaultModule(char *moduleName);
+
+#endif

--- a/src/utils-conf.h
+++ b/src/utils-conf.h
@@ -1,5 +1,5 @@
 #ifndef UTILS_CONF_H
-#define UTILS_CONF_H
+#define UTILS_CONF_H 1
 
 void setDefaultModule(char *moduleName);
 


### PR DESCRIPTION
** CURRENTLY "JUST WORKS". WILL REPLACE WITH SOMETHING RELATED TO SAT-CFG.C WHEN I HAVE TIME **

Utility function created to overwrite the  contents of ~/.config/Gpredict/gpredict.cfg in order to change the module that loads upon launching gpredict.

Notes:
* I assume this works because gpredict is run using `sudo`. Without sudo, it may not have proper read-write permissions in the .config file (a segmentation fault actually showed up when I tried it)
* This also assumes that:
    * the configuration file is located at `~/.config/Gpredict/gpredict.cfg`
    * gpredict was installed in `~/gpredict`